### PR TITLE
Enabling replace behavior and making insertion bit smarter

### DIFF
--- a/src/components/search-icon.tsx
+++ b/src/components/search-icon.tsx
@@ -6,8 +6,8 @@ function SearchIcon(props: React.HTMLProps<SVGSVGElement>) {
       viewBox="0 0 32 32"
       width={32}
       height={32}
-      clip-rule="evenodd"
-      fill-rule="evenodd"
+      clipRule="evenodd"
+      fillRule="evenodd"
       {...props}
     >
       <path d="m20 15c0 2.7614-2.2386 5-5 5s-5-2.2386-5-5 2.2386-5 5-5 5 2.2386 5 5zm-1.1256 4.5815c-1.0453.8849-2.3975 1.4185-3.8744 1.4185-3.3137 0-6-2.6863-6-6s2.6863-6 6-6 6 2.6863 6 6c0 1.4769-.5336 2.8291-1.4185 3.8744l4.2721 4.272-.7072.7072z" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,11 +24,11 @@ figma.ui.onmessage = message => {
       {
         // in case our selected node can accept children, place icon in it
         if(canAcceptChildren(topSelectedItem)) {
-          targetParent = topSelectedItem as ((FrameNode & GeometryMixin))
+          targetParent = topSelectedItem as (FrameNode & GeometryMixin)
         // in case selected note can not accept children (like a rectangle)
         // but its parent can, place icon in the parent
         } else {
-          targetParent = topSelectedItem.parent as ((FrameNode & GeometryMixin))
+          targetParent = topSelectedItem.parent as (FrameNode & GeometryMixin)
         }
         targetX = targetParent.type=="FRAME" ? 0 : targetParent.x
         targetY = targetParent.type=="FRAME" ? 0 : targetParent.y

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,49 @@ import { icons } from 'feather-icons'
 figma.showUI(__html__, { width: 300, height: 400 })
 
 figma.ui.onmessage = message => {
-  const icon = figma.createNodeFromSvg(icons[message.type].toSvg())
+  let targetParent : (BaseNode & ChildrenMixin) | null = figma.currentPage
+  let targetX : number = figma.viewport.center.x
+  let targetY : number = figma.viewport.center.y
+
+  if(figma.currentPage.selection.length > 0) {
+    const topSelectedItem : BaseNode = figma.currentPage.selection[0]
+
+    // if the top selected item is an icon, delete it and select
+    // its parent and position for insertion of the new one
+    if(topSelectedItem.getPluginData('iconType')) {
+      const selectedIcon = topSelectedItem as (FrameNode & GeometryMixin)
+      targetParent = selectedIcon.parent 
+      targetX = selectedIcon.x
+      targetY = selectedIcon.y
+      selectedIcon.remove()
+    } else {
+      if(canAcceptChildren(topSelectedItem) || 
+         canAcceptChildren(topSelectedItem.parent))
+      {
+        // in case our selected node can accept children, place icon in it
+        if(canAcceptChildren(topSelectedItem)) {
+          targetParent = topSelectedItem as ((FrameNode & GeometryMixin))
+        // in case selected note can not accept children (like a rectangle)
+        // but its parent can, place icon in the parent
+        } else {
+          targetParent = topSelectedItem.parent as ((FrameNode & GeometryMixin))
+        }
+        targetX = targetParent.type=="FRAME" ? 0 : targetParent.x
+        targetY = targetParent.type=="FRAME" ? 0 : targetParent.y
+      }
+    }
+  }
+  const icon = figma.createNodeFromSvg(icons[message.type].toSvg()) as (FrameNode & GeometryMixin)
+  icon.setPluginData('iconType',message.type)
   icon.name = message.type
-  icon.x = figma.viewport.center.x
-  icon.y = figma.viewport.center.y
+  icon.x = targetX
+  icon.y = targetY
+  if (targetParent){
+    targetParent.appendChild(icon)
+  }
   figma.currentPage.selection = [icon]
 }
+
+const canAcceptChildren = (node:BaseNode | null) =>
+  ["FRAME","PAGE","GROUP", "COMPONENT"].includes(node ? node.type : '')
+

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -34,7 +34,7 @@ function App() {
           }}
         >
           {results.map(icon => (
-            <IconButton name={icon.name} contents={icon.contents} />
+            <IconButton key={icon.name} name={icon.name} contents={icon.contents} />
           ))}
         </div>
         <div


### PR DESCRIPTION
First of all, I find myself using this plugin all the time and we're heavy Feather users at @prisma so kudos for making this! This PR is addressing some common steps I need to take almost every time I use the plugin.

- If I have an icon already selected, selecting an icon from the UI will replace it instead of placing a new one. This is useful when I accidentally select the wrong icon, or when I want to replace one that already exists.
- If I have a layer selected, it will try to place it in a place in the hierarchy that has a high chance of being correct (as opposed to the page, which almost never is):
  - If my selected layer accepts children (like a group or a frame), place the icon inside.
  - if my selected layer doesn't accept children (like a rectangle, or an ellipse), place the icon next to it in the hierarchy.

If this is desirable, the next PR I'd like to propose is matching the stroke color of a placed icon if replacing. I also addressed the console errors.